### PR TITLE
Fix memory overflow that causes sound corruption (#6)

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -27,7 +27,7 @@ permissions:
 # To avoid sound corruption when building with ubuntu-latest (22.04), build with ubuntu-20.04 (Issue #6)
 jobs:
     build-release:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         name: Build and create release
         steps:
           

--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -53,11 +53,13 @@ jobs:
                       echo "The string starts with 'refs/tags/'."
                       tag="${input_string#$prefix}"     
                       echo "Tag is ${tag}"
-                      sed -i "s/^[[:space:]]*pico_set_program_version(.*/pico_set_program_version(${{ env.APP_NAME }} \"$tag\")/" CMakeLists.txt   
+                      sed -i "s/^[[:space:]]*pico_set_program_version(.*/pico_set_program_version(${{ env.APP_NAME }} \"$tag\")/" CMakeLists.txt
+                      sed -i "s/VX.X/$tag/" menu.h  
                  else
                       echo "The string does not start with 'refs/tags/'."
                  fi
                  grep "pico_set_program_version" CMakeLists.txt
+                 grep SWVERSION menu.h
 
           - name: Install Pico SDk
             run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Binaries are at the end of this page.
 
 # Release notes
 
+## v0.5
+
+### Features
+
+- Display program version on lower right corber of the menu screen.
+
+### Fixes
+
+
 ## v0.4
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Binaries are at the end of this page.
 
 ### Fixes
 
+- Fix memory overflow that causes sound corruption [(issue #6)](https://github.com/fhoedemakers/pico-smsplus/issues/6).
 
 ## v0.4
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ Gamepad buttons:
 
 ## Building from source
 
-> Emulator sound output is corrupted when building using arm-none-eabi-gcc v10.3.1 or higher. See issue [#6](https://github.com/fhoedemakers/pico-smsplus/issues/6) for more information.
-
 When using Visual Studio code, make sure to build in Release or RelWithDbinfo mode, as the emulator is too slow in the other modes.
 
 Build shell scripts are available:

--- a/menu.cpp
+++ b/menu.cpp
@@ -176,6 +176,7 @@ void displayRoms(Frens::RomLister romlister, int startIndex)
     ClearScreen(screenBuffer, bgcolor);
     putText(1, 0, "Choose a rom to play:", fgcolor, bgcolor);
     putText(1, SCREEN_ROWS - 1, "A: Select, B: Back", fgcolor, bgcolor);
+    putText(SCREEN_COLS - strlen(SWVERSION), SCREEN_ROWS - 1,SWVERSION, fgcolor, bgcolor);
     for (auto index = startIndex; index < romlister.Count(); index++)
     {
         if (y <= ENDROW)

--- a/menu.h
+++ b/menu.h
@@ -2,7 +2,7 @@
 #define MENU_H
 #define ROMSELECT
 #define ROMINFOFILE "/currentloadedrom.txt"
-
+#define SWVERSION "VX.X"
 void processinput(DWORD *pdwPad1, DWORD *pdwPad2, DWORD *pdwSystem, bool ignorepushed );
 void menu(uintptr_t NES_FILE_ADDR, char *errorMessage, bool isFatalError, bool reset);
 char getcharslicefrom8x8font(char c, int rowInChar);

--- a/smsplus/sms.c
+++ b/smsplus/sms.c
@@ -79,9 +79,10 @@ void sms_init(void) {
 
 void sms_reset(void) {
     /* Clear SMS context */
-    __builtin_memset(sms.dummy, 0, 0x2000);
-    __builtin_memset(sms.ram, 0, 0x2000);
-    //memset(sms.sram, 0, 0x8000);
+
+    __builtin_memset(sram, 0, SRAMSIZEBYTES);
+    __builtin_memset(sms.ram, 0, RAMSIZEBYTES);
+
     sms.paused = sms.save = sms.port_3F = sms.port_F2 = sms.irq = 0x00;
     sms.psg_mask = 0xFF;
 

--- a/smsplus/sms.h
+++ b/smsplus/sms.h
@@ -17,11 +17,16 @@ static uint8_t smsBufferLine[SMS_WIDTH];
 // FH - 2019-06-30: Added support for RGB444 in stead of RGB565
 static int palette444[32];
 
-static uint8_t sram[0x8000];
+#define SRAMSIZE 0x8000
+#define SRAMSIZEBYTES ( 0x8000 * sizeof(uint8) )
+#define RAMSIZE  0x2000
+#define RAMSIZEBYTES  (0x2000 * sizeof(uint8))
+
+static uint8 sram[SRAMSIZE];
 /* SMS context */
 typedef struct {
     uint8 *dummy; //JMD: Point this into outher space plz.
-    uint8 ram[0x2000];
+    uint8 ram[RAMSIZE];
 //    uint8 sram[0x8000];
     uint8 *sram;
     uint8 fcr[4];


### PR DESCRIPTION
1. Closes #6 
2. Additionally: Added program version in lower right corner of menu

Github action now builds again using the latest ubuntu release.

