### PR TITLE
Refactor audio handling, fix save state regression, and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ To enable audio over hdmi, make sure external audio is disabled in the settings 
 
 - Added option in settings menu to enter bootsel mode for flashing firmware. 
 
+## Fixes
+
+- Fix for losing signal on monitors: Removed _not_in_flash_func predicates from emulator code on RP2350. (???)
+
 # previous changes
 
 See [HISTORY.md](https://github.com/fhoedemakers/pico-smsplus/blob/main/HISTORY.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,24 @@
 
 [See setup section in in Pico-infoNesPlus readme how to install and wire up](https://github.com/fhoedemakers/pico-infonesPlus#pico-setup)
 
-# v0.24 Release Notes
+# v0.25 Release notes
 
-## Fixes
+For the boards that use HSTX in stead of PicoDVI: HDMI audio is now supported via the new HSTX video driver. Huge thanks to [@fliperama86](https://github.com/fliperama86) for the awesome [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that made this possible and for helping out.
 
-- Emulator buffers are now allocated dynmically. 
-- Pimoroni Pico DV Demo base: Settings are accessible from within the menu again.
-- ENding a game will now go back to the menu instead of rebooting the board.
+- Adafruit Fruit Jam.
+- Murmulator M2. 
+
+Other RP2350 configurations that now use HSTX (GPIO 12 - 19) in stead of PicoDVI:
+
+- [Breadboard](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
+- [PCB](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)
+- [Adafruit Metro RP2350](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#adafruit-metro-rp2350)
+  
+All the other boards still use PicoDVI.
+
+To enable audio over hdmi, make sure external audio is disabled in the settings menu.
+
+- Added option in settings menu to enter bootsel mode for flashing firmware. 
 
 # previous changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
+HSTX video and audio for supported boards
+
 # General Info
+
+> **In a nutshell:** **HSTX replaces PicoDVI** on more boards, **HSTX now has picture and sound over HDMI**, in-game game reset, automatic headphone detection on Fruit Jam, and a save-state crash fix.
 
 [Binaries for each configuration and PCB design are at the end of this page](#downloads___).
 
@@ -9,27 +13,82 @@
 
 # v0.25 Release notes
 
-For the boards that use HSTX in stead of PicoDVI: HDMI audio is now supported via the new HSTX video driver. Huge thanks to [@fliperama86](https://github.com/fliperama86) for the awesome [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that made this possible and for helping out.
+This release replaces PicoDVI with HSTX on more boards, HSTX now also carries audio over HDMI,
+adds smoother on-screen motion, a few new in-game conveniences, and a
+handful of fixes that make the emulator more reliable in everyday use.
 
-- Adafruit Fruit Jam.
-- Murmulator M2. 
+A huge thank you to [@fliperama86](https://github.com/fliperama86) for the
+excellent [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that
+made the new HDMI output possible, and for all the help along the way.
 
-Other RP2350 configurations that now use HSTX (GPIO 12 - 19) in stead of PicoDVI:
+## What's new
 
-- [Breadboard](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
-- [PCB](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)
+### Video and sound over a single HDMI cable
+
+On the technical side, several RP2350 board configurations have switched
+from the **PicoDVI** software-driven video output to **HSTX**, the
+RP2350's dedicated High-Speed Serial Transmit hardware (GPIO 12 – 19).
+HSTX has been used for video on some boards before, but in this release
+it also carries **audio embedded in the HDMI stream** for the first
+time — that's the new capability HSTX gains here. (PicoDVI has always
+been able to embed audio; HSTX is just catching up on that front while
+offloading the work from the CPU to dedicated hardware.)
+
+In practice, on these boards picture and sound now travel together over a
+single HDMI cable — no separate audio jack needed:
+
+- Adafruit Fruit Jam
+- Murmulator M2
+
+These RP2350 boards have also been switched from PicoDVI to HSTX. They
+keep using a separate audio output for now, but picture quality should
+look the same and the change frees up CPU cycles for future improvements:
+
+- [Breadboard build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
+- [PCB build](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)
 - [Adafruit Metro RP2350](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#adafruit-metro-rp2350)
-  
-All the other boards still use PicoDVI.
 
-To enable audio over hdmi, make sure external audio is disabled in the settings menu.
+All other boards continue to use PicoDVI and work as before.
 
-- Added option in settings menu to enter bootsel mode for flashing firmware. 
+### Smoother gameplay
+
+Frame timing now follows the display's own refresh signal, which removes
+small stutters and gives the picture a more consistent, smooth feel.
+
+### New options and conveniences
+
+- **Reset the running game** from the in-game menu — no need to power-cycle
+  the device to restart.
+- **Enter flashing mode from the settings menu**, so you can update the
+  firmware without having to unplug the device and hold the BOOTSEL button.
+- **Scanline effect for HDMI boards** — turn on the classic CRT scanline
+  look from the settings menu when running on an HDMI-capable board.
+
+### Adafruit Fruit Jam
+
+- **Automatic headphone detection.** Plug headphones in and the built-in
+  speaker mutes itself; unplug them and the speaker comes back. The old
+  manual mute setting and pushbutton-1 mute shortcut have been removed —
+  they are no longer needed.
 
 ## Fixes
 
-- Fix for losing signal on monitors: Removed _not_in_flash_func predicates from emulator code on RP2350. (???)
-- Fix save state regression introduced in v0.24: loading a save state caused a memory allocation  panic. Note: save states written by previous v0.25 dev builds are not compatible with this fix.
+- **Save states work again.** A bug introduced in v0.24 could crash the
+  emulator when loading a saved game. This is now fixed. Note: save state
+  files created by earlier v0.25 development builds are not compatible
+  with this fix and will need to be re-created.
+- **Picture-loss recovery.** On the new HSTX output when set to
+  video-only (DVI) mode, the monitor could occasionally lose the picture.
+  The emulator now detects this and automatically restores the signal
+  without needing a restart. (Not observed in full HDMI mode, but the
+  same safety net is enabled there too just in case.)
+- **Screen cropping fix.** A small visual glitch where part of the game
+  picture was being cut off incorrectly has been corrected.
+
+## Credits
+
+Updated to acknowledge new contributors — see the splash screen on
+startup.
 
 # previous changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ To enable audio over hdmi, make sure external audio is disabled in the settings 
 ## Fixes
 
 - Fix for losing signal on monitors: Removed _not_in_flash_func predicates from emulator code on RP2350. (???)
+- Fix save state regression introduced in v0.24: loading a save state caused a memory allocation  panic. Note: save states written by previous v0.25 dev builds are not compatible with this fix.
 
 # previous changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # CHANGELOG
 
-HSTX video and audio for supported boards
+> **HSTX replaces PicoDVI** on more boards, **HSTX now has picture and sound over HDMI**, in-game game reset, automatic headphone detection on Fruit Jam, and a save-state crash fix.
 
 # General Info
 
-> **In a nutshell:** **HSTX replaces PicoDVI** on more boards, **HSTX now has picture and sound over HDMI**, in-game game reset, automatic headphone detection on Fruit Jam, and a save-state crash fix.
 
 [Binaries for each configuration and PCB design are at the end of this page](#downloads___).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ target_compile_definitions(${projectname} PUBLIC
     GPIOHSTXINVERTED=${GPIOHSTXINVERTED} # Set to 1 if HSTX pins are inverted: D- = D+ -1
     ENABLE_VU_METER=${ENABLE_VU_METER} # Enable VU meter (fruitjam NeoPixel leds)
     WIIPAD_DELAYED_START=${WIIPAD_DELAYED_START}
+    #HSTX_DEBUG=1
     #ENABLEDVI=1
     #PICO_DEBUG_MALLOC=1
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,14 @@ message("* Current build type is : ${CMAKE_BUILD_TYPE}")
 
 
 if (NOT HW_CONFIG)
-    set(HW_CONFIG 1 CACHE STRING "Select the hardware configuration for your board")       
+    set(HW_CONFIG 8 CACHE STRING "Select the hardware configuration for your board")       
 endif()
 if (NOT USE_HSTX)
     set(USE_HSTX 1 CACHE STRING "Use HSTX for display output when possible")
 endif()
 include("pico_shared/BoardConfigs.cmake")
 if (NOT PICO_BOARD )
-    set(PICO_BOARD pico CACHE STRING "Board type")
+    set(PICO_BOARD pico2 CACHE STRING "Board type")
     message("PICO_BOARD not set, using default: ${PICO_BOARD}")
 endif()
 add_definitions( -DNDEBUG )
@@ -100,6 +100,7 @@ target_compile_definitions(${projectname} PUBLIC
     GPIOHSTXINVERTED=${GPIOHSTXINVERTED} # Set to 1 if HSTX pins are inverted: D- = D+ -1
     ENABLE_VU_METER=${ENABLE_VU_METER} # Enable VU meter (fruitjam NeoPixel leds)
     WIIPAD_DELAYED_START=${WIIPAD_DELAYED_START}
+    #ENABLEDVI=1
     #PICO_DEBUG_MALLOC=1
 )
 if(NOT PICO_PLATFORM STREQUAL "rp2040")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ target_compile_definitions(${projectname} PUBLIC
     ENABLE_VU_METER=${ENABLE_VU_METER} # Enable VU meter (fruitjam NeoPixel leds)
     WIIPAD_DELAYED_START=${WIIPAD_DELAYED_START}
     #HSTX_DEBUG=1
-    #ENABLEDVI=1
+    ENABLEDVI=1
     #PICO_DEBUG_MALLOC=1
 )
 if(NOT PICO_PLATFORM STREQUAL "rp2040")

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # History of changes
 
+# v0.24 Release Notes
+
+## Fixes
+
+- Emulator buffers are now allocated dynmically. 
+- Pimoroni Pico DV Demo base: Settings are accessible from within the menu again.
+- Ending a game will now go back to the menu instead of rebooting the board.
+
 # v0.23 Release Notes
 
 - Implemented savestates [#140](https://github.com/fhoedemakers/pico-infonesPlus/issues/140)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ You can organize the roms in directories. A menu is displayed on which you can s
 
 Supports two controllers for two player Master System games. [See "about two player games" below for specifics and limitations](#about-two-player-games) 
 
+Save and load state possible.
+
+Battery backed saves stored on SD for games that support this. 
+
 See the [releases](https://github.com/fhoedemakers/pico-smsplus/releases/latest) page for the supported RP2040/RP2350 boards.
 
 ***

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ These boards already contain an RP2040 cpu, a separate Raspberry Pi Pico is not 
 - [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107)
   Use the breadboard config or Pimoroni Pico DV Demo base. This board does not fit the PCB because of the SP/CE connector on back of the board.
   The PSRAM on the board is used in stead of flash to load the roms from SD.
+- [Waveshare RP2350-PiZero](https://www.waveshare.com/rp2350-pizero.htm)
+
 
 ## Waveshare RP2040 & RP2350 Zero
 

--- a/main.cpp
+++ b/main.cpp
@@ -74,6 +74,7 @@ const int8_t g_settings_visibility_sms[MOPT_COUNT] = {
     0,                               // Border Mode (Super Gameboy style borders not applicable for SMS/Game Gear)
     0,                               // Rapid Fire on A
     0,                               // Rapid Fire on B
+     1                                // Enter bootsel mode (moved from button combo to settings menu, but keep option visible for NES)
 };
 const uint8_t g_available_screen_modes_sms[] = {
 #if PICO_RP2350

--- a/main.cpp
+++ b/main.cpp
@@ -725,7 +725,8 @@ void loadoverlay()
 
 static inline int ProcessAfterFrameIsRendered()
 {
-    Frens::PaceFrames60fps(false);
+    //Frens::PaceFrames60fps(false);
+    Frens::waitForVSync();
 #if NES_PIN_CLK != -1
     nespad_read_start();
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -74,7 +74,7 @@ const int8_t g_settings_visibility_sms[MOPT_COUNT] = {
     0,                               // Border Mode (Super Gameboy style borders not applicable for SMS/Game Gear)
     0,                               // Rapid Fire on A
     0,                               // Rapid Fire on B
-     1                                // Enter bootsel mode (moved from button combo to settings menu, but keep option visible for NES)
+    1                                // Enter bootsel mode
 };
 const uint8_t g_available_screen_modes_sms[] = {
 #if PICO_RP2350

--- a/main.cpp
+++ b/main.cpp
@@ -725,8 +725,8 @@ void loadoverlay()
 
 static inline int ProcessAfterFrameIsRendered()
 {
-    //Frens::PaceFrames60fps(false);
-    Frens::waitForVSync();
+    Frens::PaceFrames60fps(false);
+    //Frens::waitForVSync();
 #if NES_PIN_CLK != -1
     nespad_read_start();
 #endif
@@ -1203,6 +1203,7 @@ int main()
         }
         loadoverlay();
         load_rom(ROM_FILE_ADDR, fileSize, isGameGear);
+        Frens::PaceFrames60fps(true); 
         // Initialize all systems and power on
         system_init(SMS_AUD_RATE);
         // load state if any

--- a/main.cpp
+++ b/main.cpp
@@ -1121,6 +1121,8 @@ int main()
     isFatalError = !Frens::initAll(selectedRom, CPUFreqKHz, MARGINTOP, MARGINBOTTOM, AUDIOBUFFERSIZE, false, true);
 #if !HSTX
     scaleMode8_7_ = Frens::applyScreenMode(settings.screenMode);
+#else
+    hstx_setScanLines(settings.flags.scanlineOn);
 #endif
     bool showSplash = true;
     g_settings_visibility = g_settings_visibility_sms;

--- a/main.cpp
+++ b/main.cpp
@@ -1070,27 +1070,20 @@ void in_ram(process)(void)
     {
         processinput(&pdwPad1, &pdwPad2, &pdwSystem, false, nullptr);
         sms_frame(0);
-#if !HSTX
 #if EXT_AUDIO_IS_ENABLED
         if (settings.flags.useExtAudio == 1)
         {
             processaudioPerFrameI2S();
-        }
-        else
-        {
-            processaudioPerFrameDVI();
-        }
-#else
-        processaudioPerFrameDVI();
+        } else
 #endif
-#else
-        if (settings.flags.useExtAudio == 1)
         {
-            processaudioPerFrameI2S();
-        } else {
+#if !HSTX
+            processaudioPerFrameDVI();
+#else
+       
             processaudioPerFrameHSTX();
+#endif 
         }
-#endif // !HSTX
         ProcessAfterFrameIsRendered();
     }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -58,17 +58,19 @@ static uint32_t CPUFreqKHz = EMULATOR_CLOCKFREQ_KHZ;
 // Order must match enum in menu_options.h
 const int8_t g_settings_visibility_sms[MOPT_COUNT] = {
     0,                               // Exit Game, or back to menu. Always visible when in-game.
+    0,                               // Reset Game. Always visible when in-game.
     0,                               // Save / Restore State
     !HSTX,                           // Screen Mode (only when not HSTX)
     HSTX,                            // Scanlines toggle (only when HSTX)
     1,                               // FPS Overlay
     0,                               // Audio Enable
     0,                               // Frame Skip
-    (EXT_AUDIO_IS_ENABLED), // External Audio
+    (HSTX && ENABLEDVI),             // Display Mode HDMI or DVI
+    (EXT_AUDIO_IS_ENABLED),          // External Audio
     1,                               // Font Color
     1,                               // Font Back Color
     ENABLE_VU_METER,                 // VU Meter
-    (HW_CONFIG == 8),                // Fruit Jam Internal Speaker
+    //(HW_CONFIG == 8),              // Fruit Jam Internal Speaker
     (HW_CONFIG == 8),                // Fruit Jam Volume Control
     0,                               // DMG Palette (SMS/Game Gear emulator does not use GameBoy palettes)
     0,                               // Border Mode (Super Gameboy style borders not applicable for SMS/Game Gear)
@@ -100,7 +102,8 @@ const uint8_t g_available_screen_modes_sms[] = {
 #define FPSSTART (((MARGINTOP + 7) / 8) * 8)
 #define FPSEND ((FPSSTART) + 8)
 
-bool reset = false;
+static bool reset = false;
+static bool resetGame = false;
 
 #if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
 // Cached Wii pad state updated once per frame in ProcessAfterFrameIsRendered()
@@ -725,6 +728,7 @@ void loadoverlay()
 
 static inline int ProcessAfterFrameIsRendered()
 {
+    Frens::pollHeadPhoneJack();
     Frens::PaceFrames60fps(false);
     //Frens::waitForVSync();
 #if NES_PIN_CLK != -1
@@ -783,6 +787,10 @@ static inline int ProcessAfterFrameIsRendered()
         {
             loadSaveStateMenu = true;
             quickSaveAction = SaveStateTypes::NONE;
+        }
+        if ( rval == 5)
+        {
+            reset = resetGame = true;
         }
         loadoverlay();
     }
@@ -1073,7 +1081,7 @@ void in_ram(process)(void)
         processinput(&pdwPad1, &pdwPad2, &pdwSystem, false, nullptr);
         sms_frame(0);
 #if EXT_AUDIO_IS_ENABLED
-        if (settings.flags.useExtAudio == 1)
+        if (settings.flags.useExtAudio == 1 || Frens::isHeadPhoneJackConnected())
         {
             processaudioPerFrameI2S();
         } else
@@ -1140,7 +1148,7 @@ int main()
         reset = false;
         fileSize = 0;
         isGameGear = false;
-        EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
+        //EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
         if (Frens::isPsramEnabled())
         {
             // Detect rom type from memory
@@ -1201,18 +1209,22 @@ int main()
         {
             printf("No auto-save configured for this ROM.\n");
         }
-        loadoverlay();
-        load_rom(ROM_FILE_ADDR, fileSize, isGameGear);
-        Frens::PaceFrames60fps(true); 
-        // Initialize all systems and power on
-        system_init(SMS_AUD_RATE);
-        // load state if any
-        // system_load_state();
+        do {
+            reset = resetGame = false;
+            loadoverlay();
+            load_rom(ROM_FILE_ADDR, fileSize, isGameGear);
+            Frens::PaceFrames60fps(true); 
+            // Initialize all systems and power on
+            system_init(SMS_AUD_RATE);
+            // load state if any
+            // system_load_state();
 
-        system_reset();
-        printf("Starting game\n");
-        process();
-        system_shutdown();
+            system_reset();
+            printf("Starting game\n");
+            Frens::PaceFrames60fps(true); 
+            process();
+            system_shutdown();
+        } while (resetGame);
         selectedRom[0] = 0;
         showSplash = false;
 #if ENABLE_VU_METER

--- a/main.cpp
+++ b/main.cpp
@@ -1212,13 +1212,11 @@ int main()
         do {
             reset = resetGame = false;
             loadoverlay();
-            load_rom(ROM_FILE_ADDR, fileSize, isGameGear);
-            Frens::PaceFrames60fps(true); 
+            load_rom(ROM_FILE_ADDR, fileSize, isGameGear); 
             // Initialize all systems and power on
             system_init(SMS_AUD_RATE);
             // load state if any
             // system_load_state();
-
             system_reset();
             printf("Starting game\n");
             Frens::PaceFrames60fps(true); 

--- a/main.cpp
+++ b/main.cpp
@@ -495,7 +495,7 @@ extern "C" void in_ram(sms_render_line)(int line, const uint8_t *buffer)
         sbuffer = currentLineBuf + 32 + (IS_GG ? 48 : 0);
         if (buffer)
         {
-            for (int i = screenCropX + (IS_GG ? 0 : 8); i < BMP_WIDTH - screenCropX; i++)
+            for (int i = screenCropX ; i < BMP_WIDTH - screenCropX; i++)
             {
                 sbuffer[i - screenCropX] = palette444[(buffer[i + BMP_X_OFFSET]) & 31];
             }
@@ -524,7 +524,7 @@ extern "C" void in_ram(sms_render_line)(int line, const uint8_t *buffer)
     sbuffer = currentLineBuf + 32 + (IS_GG ? 48 : 0);
     if (buffer)
     {
-        for (int i = screenCropX + (IS_GG ? 0 : 8); i < BMP_WIDTH - screenCropX; i++)
+        for (int i = screenCropX ; i < BMP_WIDTH - screenCropX; i++)
         {
             sbuffer[i - screenCropX] = palette444[(buffer[i + BMP_X_OFFSET]) & 31];
         }

--- a/smsplus/loadrom.c
+++ b/smsplus/loadrom.c
@@ -95,7 +95,6 @@ typedef struct
 
 //     return 1;
 // }
-void *frens_f_malloc(size_t size);
 int load_rom(uintptr_t addr,   int size, bool isGameGear)
 {
     uint8_t *start = (uint8_t *)addr;
@@ -106,8 +105,6 @@ int load_rom(uintptr_t addr,   int size, bool isGameGear)
     }
     sms.use_fm = 0;
     sms.country = TYPE_OVERSEAS;
-    sms.ram = (uint8 *)frens_f_malloc(RAMSIZEBYTES);    
-    sms.sram = (uint8 *)frens_f_malloc(SRAMSIZEBYTES);
     sms.dummy = smsBufferLine;
     bitmap.data = smsBufferLine;
     bitmap.width = BMP_WIDTH;

--- a/smsplus/shared.h
+++ b/smsplus/shared.h
@@ -29,7 +29,9 @@ extern "C" {
 #define strcasecmp stricmp
 #endif
 #endif
-
+#if PICO_RP2350
+#define in_ram
+#endif
 #ifndef in_ram
 #ifdef PICO_BOARD
 #include <pico.h>

--- a/smsplus/system.c
+++ b/smsplus/system.c
@@ -38,7 +38,9 @@ void system_init(int rate) {
     cachePtr = (int16 *)frens_f_malloc(512 * 4 * sizeof(int16));
     cacheStore = (uint8 *)frens_f_malloc(CACHEDTILES * 64 * sizeof(uint8));
     cacheStoreUsed = (uint8 *)frens_f_malloc(CACHEDTILES * sizeof(uint8));
-    if (!cachePtr || !cacheStore || !cacheStoreUsed) {
+    sms.ram  = (uint8 *)frens_f_malloc(RAMSIZEBYTES);
+    sms.sram = (uint8 *)frens_f_malloc(SRAMSIZEBYTES);
+    if (!cachePtr || !cacheStore || !cacheStoreUsed || !sms.ram || !sms.sram) {
         printf("Failed to allocate memory for cache\n");
         exit(1);
     }
@@ -121,6 +123,13 @@ void system_shutdown(void)
     frens_f_free(cachePtr);
     frens_f_free(sms.sram);
     frens_f_free(sms.ram);
+    snd.buffer[0] = NULL;
+    snd.buffer[1] = NULL;
+    cacheStoreUsed = NULL;
+    cacheStore = NULL;
+    cachePtr = NULL;
+    sms.sram = NULL;
+    sms.ram = NULL;
 
     if (snd.enabled)
     {
@@ -158,6 +167,20 @@ bool system_save_state(FIL *fd) {
     fr = f_write(fd, &sms, sizeof(t_sms), &bw);
     if (fr != FR_OK || bw != sizeof(t_sms)) {
         printf("Error writing SMS context: fr=%d wrote=%u expected=%u\n", fr, bw, (unsigned)sizeof(t_sms));
+        return false;
+    }
+
+    /* Save SMS work RAM contents (sms.ram is a pointer; struct above only stores the address) */
+    fr = f_write(fd, sms.ram, RAMSIZEBYTES, &bw);
+    if (fr != FR_OK || bw != RAMSIZEBYTES) {
+        printf("Error writing SMS RAM: fr=%d wrote=%u expected=%u\n", fr, bw, (unsigned)RAMSIZEBYTES);
+        return false;
+    }
+
+    /* Save SMS SRAM contents */
+    fr = f_write(fd, sms.sram, SRAMSIZEBYTES, &bw);
+    if (fr != FR_OK || bw != SRAMSIZEBYTES) {
+        printf("Error writing SMS SRAM: fr=%d wrote=%u expected=%u\n", fr, bw, (unsigned)SRAMSIZEBYTES);
         return false;
     }
 
@@ -211,10 +234,32 @@ bool system_load_state(FIL *fd) {
         return false;
     }
 
-    /* Load SMS context */
+    /* Load SMS context — preserve runtime pointers across the struct read.
+       sms.dummy/ram/sram are pointers into local heap/static memory; the values
+       written to the save file at save time are stale and must not be used. */
+    uint8 *saved_dummy = sms.dummy;
+    uint8 *saved_ram   = sms.ram;
+    uint8 *saved_sram  = sms.sram;
     fr = f_read(fd, &sms, sizeof(t_sms), &br);
+    sms.dummy = saved_dummy;
+    sms.ram   = saved_ram;
+    sms.sram  = saved_sram;
     if (fr != FR_OK || br != sizeof(t_sms)) {
         printf("Error reading SMS context: fr=%d read=%u expected=%u\n", fr, br, (unsigned)sizeof(t_sms));
+        return false;
+    }
+
+    /* Load SMS work RAM contents */
+    fr = f_read(fd, sms.ram, RAMSIZEBYTES, &br);
+    if (fr != FR_OK || br != RAMSIZEBYTES) {
+        printf("Error reading SMS RAM: fr=%d read=%u expected=%u\n", fr, br, (unsigned)RAMSIZEBYTES);
+        return false;
+    }
+
+    /* Load SMS SRAM contents */
+    fr = f_read(fd, sms.sram, SRAMSIZEBYTES, &br);
+    if (fr != FR_OK || br != SRAMSIZEBYTES) {
+        printf("Error reading SMS SRAM: fr=%d read=%u expected=%u\n", fr, br, (unsigned)SRAMSIZEBYTES);
         return false;
     }
 
@@ -318,9 +363,9 @@ bool system_load_state(FIL *fd) {
             ym2413_write(0, 1, reg[i]);
         }
 #endif
+    }
     frens_f_free(reg);
     return true;
-    }
 }
 
 void ym2413_write(int chip, int offset, int data) {

--- a/splash.cpp
+++ b/splash.cpp
@@ -35,9 +35,9 @@ void splash()
     strcpy(s, "@shuichi_takano");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 12, s, CBLUE, bgcolorSplash);
 #else
-    strcpy(s, "HSTX video driver & I2S audio");
+    strcpy(s, "HSTX video driver _ I2S audio___");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 11, s, fgcolorSplash, bgcolorSplash);
-    strcpy(s, "@frenskefrens");
+    strcpy(s, "__@fliperama86____@frenskefrens__");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 12, s, CBLUE, bgcolorSplash);
 #endif
     strcpy(s, "(S)NES/WII controller support");

--- a/state.cpp
+++ b/state.cpp
@@ -36,9 +36,8 @@ int Emulator_LoadState(const char* path)
         printf("Cannot open load state file: %d (%s)\n", fr, path);
         return -1;
     }
-    system_shutdown(); // shutdown before loading state
-    system_init(SMS_AUD_RATE); // re-init system
-    //system_reset(); // reset system
+    system_shutdown();          // tear down current emulator state
+    system_init(SMS_AUD_RATE);  // allocate fresh buffers (incl. sms.ram/sram)
     bool ok = system_load_state(fil);
     FRESULT frc = f_close(fil);
     Frens::f_free(fil);


### PR DESCRIPTION
This pull request introduces major improvements to video and audio output, adds new user conveniences, and fixes several critical bugs in the emulator. The most significant change is the adoption of HSTX (hardware HDMI output with audio) on more boards, replacing PicoDVI. This enables smoother gameplay and simplifies HDMI connections. Additional features include in-game reset, automatic headphone detection, and robust save-state handling.

**Major new features and improvements**

* Replaced PicoDVI with HSTX on more boards (notably Adafruit Fruit Jam and Murmulator M2), now supporting both video and audio over HDMI, freeing CPU resources and enabling a single-cable setup. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R90) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL17-R24) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR103-R104) [[4]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL292-R311) [[5]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL1058-R1096) [[6]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR1132-R1133)
* Smoother on-screen motion by synchronizing frame timing with the display's refresh signal. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R90) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR731-R733)
* Added scanline effect option for HDMI boards, accessible from the settings menu. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R90) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR1132-R1133)

**User experience enhancements**

* In-game game reset option added to the menu, allowing users to restart games without power cycling. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R90) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR61-R79) [[3]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR791-R794) [[4]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR1212-R1225)
* Automatic headphone detection on Adafruit Fruit Jam: plugging in headphones mutes the speaker, removing the need for manual mute controls. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R90) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR731-R733) [[3]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL1058-R1096)
* Added option to enter flashing mode from the settings menu for easier firmware updates. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R90) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR61-R79)

**Save-state and reliability fixes**

* Save states work reliably again; a previous bug that could crash the emulator when loading saves is now fixed. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R90) [[2]](diffhunk://#diff-d4d24ff75fb87b49751b1d48d00be5fbce97efd010dec0c8125a9e3c3a49e066R173-R186) [[3]](diffhunk://#diff-d4d24ff75fb87b49751b1d48d00be5fbce97efd010dec0c8125a9e3c3a49e066L214-R265)
* Save and load state features are now documented and improved, including proper handling of RAM/SRAM in save files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R15) [[2]](diffhunk://#diff-d4d24ff75fb87b49751b1d48d00be5fbce97efd010dec0c8125a9e3c3a49e066R173-R186) [[3]](diffhunk://#diff-d4d24ff75fb87b49751b1d48d00be5fbce97efd010dec0c8125a9e3c3a49e066L214-R265)
* Improved memory management: dynamic allocation and cleanup of emulator buffers and RAM/SRAM to prevent memory leaks and crashes. [[1]](diffhunk://#diff-648afe3d986261d8f2015b2b131b0e4a448d4dc6946cfde1a7a836876cee255eR3-R10) [[2]](diffhunk://#diff-d4d24ff75fb87b49751b1d48d00be5fbce97efd010dec0c8125a9e3c3a49e066L41-R43) [[3]](diffhunk://#diff-d4d24ff75fb87b49751b1d48d00be5fbce97efd010dec0c8125a9e3c3a49e066R126-R132)

**Board support and configuration**

* Default hardware configuration and board type updated to support new boards, including Waveshare RP2350-PiZero. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL17-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R84-R85)
* Updated submodule `pico_shared` to latest commit for compatibility.

**Bug fixes and visual improvements**

* Fixed a screen cropping bug where part of the game picture could be cut off. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R90) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL482-R501) [[3]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL511-R530)
* Improved picture-loss recovery: emulator now automatically restores video signal if the monitor loses picture in DVI mode.
* Credits updated to acknowledge new contributors.

These changes collectively make the emulator more robust, user-friendly, and compatible with a wider range of hardware, while improving both audiovisual quality and reliability.