### PR TITLE
Update CHANGELOG and manage PCB versions in pico_shared

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -68,9 +68,9 @@ jobs:
             with:
                 files: |
                        releases/*.uf2
-                       PCB/pico_nesPCB_v2.1.zip  
-                       PCB/Gerber_PicoNES_Mini_PCB_v2.0.zip
-                       PCB/Gerber_PicoNES_Micro_v1.2.zip
+                       pico_shared/PCB/pico_nesPCB_v2.3.zip  
+                       pico_shared/PCB/Gerber_PicoNES_Mini_PCB_v2.0.zip
+                       pico_shared/PCB/Gerber_PicoNES_Micro_v1.2.zip
                        releases/SMSPlusMetadata.zip   
                 body_path: CHANGELOG.md
           

--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -68,7 +68,7 @@ jobs:
             with:
                 files: |
                        releases/*.uf2
-                       pico_shared/PCB/pico_nesPCB_v2.3.zip  
+                       pico_shared/PCB/pico_nesPCB_v2.1.zip  
                        pico_shared/PCB/Gerber_PicoNES_Mini_PCB_v2.0.zip
                        pico_shared/PCB/Gerber_PicoNES_Micro_v1.2.zip
                        releases/SMSPlusMetadata.zip   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-> **YM2413 FM sound** for Japanese SMS games (RP2350), **Game Gear digitized speech fixed** (Sonic 2 "Segaaaa", etc.), and cleaner audio output with no more boot thump.
+> **YM2413 FM sound** for Japanese SMS games (RP2350), **Game Gear digitized speech fixed** (Sonic 2 "Segaaaa", etc.), cleaner audio output with no more boot thump, and support for the new **pico-bootLoader** multi-emulator menu.
 
 # General Info
 
@@ -29,6 +29,24 @@ Mitsutaka Okazaki.
 
 FM can be toggled in the settings menu. RP2040 builds are unchanged
 (FM is not enabled there for performance reasons).
+
+### Works with pico-bootLoader
+
+There is a new companion project,
+[pico-bootLoader](https://github.com/fhoedemakers/pico-bootLoader), that lets
+one RP2350 board hold several emulators (and a native *Doom* port) at the same
+time. Every power-on brings up a menu where you pick which one to run — no more
+plugging the board into a PC and copying a `.uf2` over just to switch systems.
+
+This release makes the Master System / Game Gear emulator one of those
+selectable entries. When it has been started from the bootloader, the in-game
+settings menu gains a **Return to emulator selection** entry so you can hop
+straight back to the picker.
+
+Nothing changes if you don't use it: the normal `.uf2` downloads below are
+still stand-alone and install exactly as before. The bootloader-ready builds
+come with the [pico-bootLoader
+release](https://github.com/fhoedemakers/pico-bootLoader/releases/latest).
 
 ### Game Gear digitized speech fixed
 
@@ -71,6 +89,13 @@ sound effects come through cleanly.
 - Internal settings-visibility table cleaned up so menu entries appear
   on exactly the boards that support them.
 - The border overlay now shows up reliably when starting a game.
+- **Random crash fixed.** The screen buffer could end up at an address the
+  processor doesn't like, which showed up as an occasional lock-up while
+  playing. It is now always placed correctly.
+- **Steadier overclocking.** Boards running at the higher clock speeds could
+  fault a few seconds into a game. The flash memory timing now follows the
+  chosen speed instead of being fixed, so those settings stay stable.
+- Builds work again with the newest version of Raspberry Pi's `picotool`.
 
 ## Credits
 
@@ -194,7 +219,7 @@ For some configurations risc-v binaries are available. It is recommended however
 | Pico 2 | [picosmsPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-smsplus/releases/latest/download/picosmsPlus_AdafruitDVISD_pico2_arm.uf2) | [Readme](https://github.com/fhoedemakers/pico-infonesPlus/blob/main/README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 | Pico 2 W | [picosmsPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-smsplus/releases/latest/download/picosmsPlus_AdafruitDVISD_pico2_w_arm.uf2) | [Readme](https://github.com/fhoedemakers/pico-infonesPlus/blob/main/README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 
-PCB [pico_nesPCB_v2.3.zip](https://github.com/fhoedemakers/pico-smsplus/releases/latest/download/pico_nesPCB_v2.3.zip)
+PCB [pico_nesPCB_v2.1.zip](https://github.com/fhoedemakers/pico-smsplus/releases/latest/download/pico_nesPCB_v2.1.zip)
 
 3D-printed case designs for PCB:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@ For some configurations risc-v binaries are available. It is recommended however
 | Pico 2 | [picosmsPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-smsplus/releases/latest/download/picosmsPlus_AdafruitDVISD_pico2_arm.uf2) | [Readme](https://github.com/fhoedemakers/pico-infonesPlus/blob/main/README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 | Pico 2 W | [picosmsPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-smsplus/releases/latest/download/picosmsPlus_AdafruitDVISD_pico2_w_arm.uf2) | [Readme](https://github.com/fhoedemakers/pico-infonesPlus/blob/main/README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 
-PCB [pico_nesPCB_v2.1.zip](https://github.com/fhoedemakers/pico-smsplus/releases/latest/download/pico_nesPCB_v2.1.zip)
+PCB [pico_nesPCB_v2.3.zip](https://github.com/fhoedemakers/pico-smsplus/releases/latest/download/pico_nesPCB_v2.3.zip)
 
 3D-printed case designs for PCB:
 


### PR DESCRIPTION
This pull request adds support for the new `pico-bootLoader` multi-emulator menu, improves compatibility and stability, and updates the workflow to use the correct PCB file paths. It also updates the changelog with new features, bug fixes, and build improvements.

**New Features and Compatibility:**
* Added support for the `pico-bootLoader` multi-emulator menu, allowing users to select the Master System / Game Gear emulator from a menu at startup and return to the menu from the in-game settings. Normal `.uf2` builds remain unchanged, while bootloader-ready builds are distributed with the bootloader release. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR33-R50)

**Bug Fixes and Stability Improvements:**
* Fixed a random crash caused by incorrect screen buffer placement, preventing occasional lock-ups during gameplay.
* Improved overclocking stability by making flash memory timing follow the selected clock speed, preventing faults at higher speeds.

**Build and Workflow Updates:**
* Updated the GitHub Actions workflow to use the correct `pico_shared/PCB/` paths for PCB files instead of the old `PCB/` directory.
* Updated the `pico_shared` submodule to the latest commit.

**Other Improvements:**
* Builds are now compatible with the latest version of Raspberry Pi's `picotool`.